### PR TITLE
Removed stdlib from types, fixed docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -607,6 +607,19 @@ Default value: `$ufw::service_name`
 
 ### <a name="ufw_route"></a>`ufw_route`
 
+This type provides Puppet with the capabilities to manage ufw routing rules.
+
+**Important**: The default action is `reject`, so traffic would be rejected
+if `action` parameter is omitted.
+
+**Autorequires**:
+* `Class[ufw::install]`
+
+#### Examples
+
+##### 
+
+```puppet
 ufw_route { 'route vpn traffic to internal net':
   ensure         => 'present',
   action         => 'allow',
@@ -619,14 +632,7 @@ ufw_route { 'route vpn traffic to internal net':
   to_ports_app   => undef,
   proto          => 'any',
 }
-
-This type provides Puppet with the capabilities to manage ufw routing rules.
-
-**Important**: The default action is `reject`, so traffic would be rejected
-if `action` parameter is omitted.
-
-**Autorequires**:
-* `Class[ufw::install]`
+```
 
 #### Properties
 
@@ -650,7 +656,7 @@ Default value: `present`
 
 ##### `from_addr`
 
-Data type: `Optional[Variant[Stdlib::IP::Address, Enum[any]]]`
+Data type: `Optional[String]`
 
 Source address. default: any
 
@@ -690,7 +696,7 @@ Default value: `any`
 
 ##### `to_addr`
 
-Data type: `Optional[Variant[Stdlib::IP::Address, Enum[any]]]`
+Data type: `Optional[String]`
 
 Destination address. default: any
 
@@ -718,6 +724,19 @@ The name of the resource you want to manage.
 
 ### <a name="ufw_rule"></a>`ufw_rule`
 
+This type provides Puppet with the capabilities to manage regular ufw rules.
+
+**Important**: The default action is `reject`, so traffic would be rejected
+if `action` parameter is omitted.
+
+**Autorequires**:
+* `Class[ufw::install]`
+
+#### Examples
+
+##### 
+
+```puppet
 ufw_rule { 'allow ssh from internal networks':
   ensure         => 'present',
   action         => 'allow',
@@ -730,14 +749,7 @@ ufw_rule { 'allow ssh from internal networks':
   to_ports_app   => 22,
   proto          => 'tcp',
 }
-
-This type provides Puppet with the capabilities to manage regular ufw rules.
-
-**Important**: The default action is `reject`, so traffic would be rejected
-if `action` parameter is omitted.
-
-**Autorequires**:
-* `Class[ufw::install]`
+```
 
 #### Properties
 
@@ -769,7 +781,7 @@ Default value: `present`
 
 ##### `from_addr`
 
-Data type: `Optional[Variant[Stdlib::IP::Address, Enum[any]]]`
+Data type: `Optional[String]`
 
 Source address. default: any
 
@@ -803,7 +815,7 @@ Default value: `any`
 
 ##### `to_addr`
 
-Data type: `Optional[Variant[Stdlib::IP::Address, Enum[any]]]`
+Data type: `Optional[String]`
 
 Destination address. default: any
 

--- a/lib/puppet/type/ufw_route.rb
+++ b/lib/puppet/type/ufw_route.rb
@@ -7,18 +7,18 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 @summary a ufw_route type controls routing rules
 @example
-ufw_route { 'route vpn traffic to internal net':
-  ensure         => 'present',
-  action         => 'allow',
-  interface_in   => 'tun0',
-  interface_out  => 'eth0',
-  log            => 'log',
-  from_addr      => 'any',
-  from_ports_app => undef,
-  to_addr        => '10.5.0.0/24',
-  to_ports_app   => undef,
-  proto          => 'any',
-}
+  ufw_route { 'route vpn traffic to internal net':
+    ensure         => 'present',
+    action         => 'allow',
+    interface_in   => 'tun0',
+    interface_out  => 'eth0',
+    log            => 'log',
+    from_addr      => 'any',
+    from_ports_app => undef,
+    to_addr        => '10.5.0.0/24',
+    to_ports_app   => undef,
+    proto          => 'any',
+  }
 
 This type provides Puppet with the capabilities to manage ufw routing rules.
 
@@ -53,7 +53,7 @@ EOS
       desc: 'Logging option.',
     },
     from_addr: {
-      type: 'Optional[Variant[Stdlib::IP::Address, Enum[any]]]',
+      type: 'Optional[String]',
       desc: 'Source address. default: any',
       default: 'any',
     },
@@ -62,7 +62,7 @@ EOS
       desc: 'Source address ports or app.',
     },
     to_addr: {
-      type: 'Optional[Variant[Stdlib::IP::Address, Enum[any]]]',
+      type: 'Optional[String]',
       desc: 'Destination address. default: any',
       default: 'any',
     },

--- a/lib/puppet/type/ufw_rule.rb
+++ b/lib/puppet/type/ufw_rule.rb
@@ -7,18 +7,18 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 @summary a ufw_rule type controls regular rules
 @example
-ufw_rule { 'allow ssh from internal networks':
-  ensure         => 'present',
-  action         => 'allow',
-  direction      => 'in',
-  interface      => undef,
-  log            => undef,
-  from_addr      => '10.1.3.0/24',
-  from_ports_app => 'any',
-  to_addr        => '10.3.0.1',
-  to_ports_app   => 22,
-  proto          => 'tcp',
-}
+  ufw_rule { 'allow ssh from internal networks':
+    ensure         => 'present',
+    action         => 'allow',
+    direction      => 'in',
+    interface      => undef,
+    log            => undef,
+    from_addr      => '10.1.3.0/24',
+    from_ports_app => 'any',
+    to_addr        => '10.3.0.1',
+    to_ports_app   => 22,
+    proto          => 'tcp',
+  }
 
 This type provides Puppet with the capabilities to manage regular ufw rules.
 
@@ -54,7 +54,7 @@ EOS
       desc: 'Logging option.',
     },
     from_addr: {
-      type: 'Optional[Variant[Stdlib::IP::Address, Enum[any]]]',
+      type: 'Optional[String]',
       desc: 'Source address. default: any',
       default: 'any',
     },
@@ -63,7 +63,7 @@ EOS
       desc: 'Source address ports or app.',
     },
     to_addr: {
-      type: 'Optional[Variant[Stdlib::IP::Address, Enum[any]]]',
+      type: 'Optional[String]',
       desc: 'Destination address. default: any',
       default: 'any',
     },

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@
 #   If the class should manage an ufw package.
 # @param [String[1]] package_name
 #   Ufw package to manage.
-# @param [String[1]] packege_ensure
+# @param [String[1]] package_ensure
 #   What state the package should be in.
 # @param [Boolean] manage_service
 #   If the module should manage the ufw service state.


### PR DESCRIPTION
According to the puppet docs:

```
Currently, only built-in Puppet 4 data types are usable. This is because the type information is required on the agent, but Puppet has not made it available yet. Even after that is implemented, modules have to wait until the functionality is widely available before being able to rely on it.
```
So I had to swap the more specific stdlib types with more generic strings. Otherwise, it did not work on agent nodes.