### PR TITLE
Added check to only attempt loading rules and routes after the ufw is installed

### DIFF
--- a/lib/puppet/provider/ufw_route/ufw_route.rb
+++ b/lib/puppet/provider/ufw_route/ufw_route.rb
@@ -23,6 +23,7 @@ class Puppet::Provider::UfwRoute::UfwRoute < Puppet::ResourceApi::SimpleProvider
 
   def get(context)
     context.debug('Returning list of routes')
+    return [] unless ufw_installed?
 
     @instances = []
     route_list_lines.each do |line|
@@ -148,5 +149,9 @@ class Puppet::Provider::UfwRoute::UfwRoute < Puppet::ResourceApi::SimpleProvider
     is = @instances.find { |r| r[:name] == name }
     params = rule_to_ufw_params_nocomment(is)
     Puppet::Util::Execution.execute("/usr/sbin/ufw route delete #{params}", failonfail: true)
+  end
+
+  def ufw_installed?
+    File.file?('/usr/sbin/ufw')
   end
 end

--- a/lib/puppet/provider/ufw_rule/ufw_rule.rb
+++ b/lib/puppet/provider/ufw_rule/ufw_rule.rb
@@ -25,6 +25,7 @@ class Puppet::Provider::UfwRule::UfwRule < Puppet::ResourceApi::SimpleProvider
 
   def get(context)
     context.debug('Returning list of rules')
+    return [] unless ufw_installed?
 
     @instances = []
     rule_list_lines.each do |line|
@@ -179,5 +180,9 @@ class Puppet::Provider::UfwRule::UfwRule < Puppet::ResourceApi::SimpleProvider
     is = @instances.find { |r| r[:name] == name }
     params = rule_to_ufw_params_nocomment(is)
     Puppet::Util::Execution.execute("/usr/sbin/ufw delete #{params}", failonfail: true)
+  end
+
+  def ufw_installed?
+    File.file?('/usr/sbin/ufw')
   end
 end


### PR DESCRIPTION
Changed to return an empty list of rules and routes if corresponding resources are running before the UFW is installed.

The [resource metatype](https://github.com/kogitoapp/puppet-ufw/blob/3679b261d3aa8393601583389746e2a59f6f12ab/manifests/init.pp#L148) seem to ignore the ordering a attempts to load rules and routes at the beginning of every run. Perhaps this behavior is made on purpose to allow puppet to calculate a diff properly to purge unmanaged resources. But at the same time, it causes issues when puppet attempts to fetch the list before UFW package is installed.