### PR TITLE
Added ufw service refresh when configuration files change

### DIFF
--- a/examples/simplerules.pp
+++ b/examples/simplerules.pp
@@ -3,6 +3,10 @@ class {'ufw':
   purge_unmanaged_rules  => true,
   purge_unmanaged_routes => true,
   rules                  => {
+    'allow ssh connections'   => {
+      'action'       => 'allow',
+      'to_ports_app' => 22,
+    },
     'enable incoming to http' => {
       'action'       => 'allow',
       'to_ports_app' => 81,
@@ -19,7 +23,7 @@ class {'ufw':
       'to_addr'        => '10.3.3.3',
       'to_ports_app'   => 2122,
     },
-  }
+  },
 }
 
 ufw_rule { 'allow ssh from internal networks':
@@ -28,7 +32,7 @@ ufw_rule { 'allow ssh from internal networks':
   interface      => undef,
   log            => undef,
   from_addr      => '10.1.3.0/24',
-  from_ports_app => 'any',
+  from_ports_app => 'OpenSSH',
   to_addr        => '10.3.0.1',
   to_ports_app   => 22,
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,4 +171,6 @@ class ufw(
   Class['ufw::install']
     -> Class['ufw::config']
     -> Class['ufw::service']
+
+  Class['ufw::config'] ~> Class['ufw::service']
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -30,6 +30,19 @@ class ufw::service(
     service { $service_name:
       ensure    => $service_ensure,
     }
+
+    # According to the official docs (https://git.launchpad.net/ufw/tree/README),
+    # to load configuration framework files changes, the user should run `ufw disable` followed by `ufw enable`.
+    # This resource should only apply when this class is notified on configuration
+    # file change and never when disabling/enabling the service.
+    -> exec { 'Disable ufw to force config reload':
+      command     => 'ufw --force disable',
+      path        => '/usr/sbin:/bin',
+      environment => ['DEBIAN_FRONTEND=noninteractive'],
+      unless      => "ufw status | grep 'Status: inactive'",
+      refreshonly => true,
+    }
+
     #TODO investigate the reasons behind https://github.com/attachmentgenie/attachmentgenie-ufw/blob/master/manifests/service.pp#L17-L22
     -> exec { "ufw --force ${action}":
       path        => '/usr/sbin:/bin',

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -14,7 +14,42 @@ describe 'ufw::service' do
         }
       end
 
-      it { is_expected.to compile }
+      context 'with service_ensure => running' do
+        it {
+          is_expected.to compile
+          is_expected.to contain_service('ufw').with('ensure' => 'running')
+          is_expected.to contain_exec('Disable ufw to force config reload').with('refreshonly' => true, 'unless' => "ufw status | grep 'Status: inactive'").that_requires('Service[ufw]')
+          is_expected.to contain_exec('ufw --force enable').with_unless("ufw status | grep 'Status: active'").that_requires(['Exec[Disable ufw to force config reload]', 'Service[ufw]'])
+        }
+      end
+
+      context 'with service_ensure => stopped' do
+        let(:params) do
+          super().merge({
+                          'service_ensure' => 'stopped',
+                        })
+        end
+
+        it {
+          is_expected.to compile
+          is_expected.to contain_service('ufw').with('ensure' => 'stopped')
+          is_expected.to contain_exec('Disable ufw to force config reload').with('refreshonly' => true, 'unless' => "ufw status | grep 'Status: inactive'").that_requires('Service[ufw]')
+          is_expected.to contain_exec('ufw --force disable').with_unless("ufw status | grep 'Status: inactive'").that_requires(['Exec[Disable ufw to force config reload]', 'Service[ufw]'])
+        }
+      end
+
+      context 'with manage_service => false' do
+        let(:params) do
+          super().merge({
+                          'manage_service' => false,
+                        })
+        end
+
+        it {
+          is_expected.to compile
+          is_expected.to have_resource_count(0)
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds ufw service refresh if one of the configuration files had changed. This should only happen on file changed, but not when service is enabled/disabled.

According to the [official README](https://git.launchpad.net/ufw/tree/README), a user needs to do `ufw disable` and `ufw enable` once something had changed in the configuration files.